### PR TITLE
Fix version file URL property

### DIFF
--- a/GameData/StockRealism/StockRealism.version
+++ b/GameData/StockRealism/StockRealism.version
@@ -1,6 +1,6 @@
 {
     "NAME":"StockRealism",
-    "URL":"https://raw.githubusercontent.com/ZombieStriker/StockRealism/master/GameData/StockRealism/StockRealism.version",
+    "URL":"https://raw.githubusercontent.com/ZombieStriker/StockRealism/main/GameData/StockRealism/StockRealism.version",
     "DOWNLOAD":"https://github.com/ZombieStriker/StockRealism/releases",
     "CHANGE_LOG_URL":"https://forum.kerbalspaceprogram.com/index.php?/topic/209861-wip-112x-stockrealism-making-the-stock-solar-system-more-realistic/",
     "VERSION":{"MAJOR":1,"MINOR":0,"PATCH":1,"BUILD":0},


### PR DESCRIPTION
Hi @ZombieStriker. The version file's `URL` property currently is a 404 (via the GitHub API) because this repo uses a `main` branch instead of `master`. Now it's fixed. Cheers!